### PR TITLE
changed API call in example script to be easier to understand

### DIFF
--- a/R-graphql/example.r
+++ b/R-graphql/example.r
@@ -4,7 +4,7 @@ library("httr")
 
 API_URL <- "https://api.santiment.net/graphql"
 # change with real Apikey
-API_KEY <- Sys.getenv("SANBASE_API_KEY")
+API_KEY <- "SANBASE_API_KEY"
 
 cli <- GraphqlClient$new(
   url = API_URL,


### PR DESCRIPTION
Changed the API entry from `API_KEY <- Sys.getenv("SANBASE_API_KEY")` to `API_KEY <- "SANBASE_API_KEY"`. Balresch had a client who needed help to get the data into R. This part  was confusing for me and apparently also for the client because we both stumbled over it.